### PR TITLE
クライアント名に制約を追加、サーバー設定の処理改善、バグ修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ build-*
 .DS_Store
 src/build/*
 src/.qtc_clangd/*
+/src/.vs/
+/src/debug/
+/src/release/
+log*.txt

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@
 * **通信タイムアウト時間** TCPクライアントにおけるレスポンスの待ち時間です。長ければ長いほどクライアントがタイムアウトしにくくなります。
 
 ## 開発環境(Qt6)
-- Windows 11 23H2
-- Qt Creator 14.0.2
-- Desktop Qt 6.8.0 MinGW 64-bit
+- Windows 11 24H2
+- Qt Creator 15.0.1
+- Desktop Qt 6.8.2 MinGW 64-bit
 
 ## 開発環境(Qt5)
 - MacOSX 10.11.3 ElCapitan

--- a/src/DesignDialog.cpp
+++ b/src/DesignDialog.cpp
@@ -45,5 +45,5 @@ void DesignDialog::Export(){
 
     mSettings->setValue( "Dark"    , GetCheckDark());
     mSettings->setValue( "Bot"     , GetCheckBot());
-    QMessageBox::information(this, tr("警告"), tr("設定は再起動後有効になります。"));
+    //QMessageBox::information(this, tr("警告"), tr("設定は再起動後有効になります。"));
 }

--- a/src/ManualClient.cpp
+++ b/src/ManualClient.cpp
@@ -34,6 +34,14 @@ void ManualClient::Startup(){
     emit WriteTeamName();
     emit Ready();
     diag->setWindowFlags(Qt::WindowStaysOnTopHint);
+
+    //画面のサイズをもとにダイアログの位置を決める
+    auto displaySize = QGuiApplication::primaryScreen()->size();
+    auto diagSize = diag->size();
+
+    //画面のサイズに合わせて場所移動(邪魔にならない場所)
+    diag->move((displaySize.width()-diagSize.width())*0.5, displaySize.height()*0.65);
+
     diag->show();
 }
 

--- a/src/SettingDialog.cpp
+++ b/src/SettingDialog.cpp
@@ -49,7 +49,7 @@ void SettingDialog::Export()
     mSettings->setValue("Gamespeed", ui->Gamespeed->value());
     mSettings->setValue("Silent", ui->SilentCheck->isChecked());
     mSettings->setValue("Maximum", ui->MaximumCheck->isChecked());
-    QMessageBox::information(this, tr("警告"), tr("設定は再起動後有効になります。"));
+    //QMessageBox::information(this, tr("警告"), tr("設定は再起動後有効になります。"));
 }
 
 void SettingDialog::openDirectory()

--- a/src/TcpClient.cpp
+++ b/src/TcpClient.cpp
@@ -1,6 +1,8 @@
 #include "TcpClient.h"
 #include <QSettings>
 #include <QRegularExpression>
+#include <QFont>
+#include <QFontMetrics>
 
 QString TCPClient::VisibilityString(QString str)
 {
@@ -187,7 +189,29 @@ QString TCPClient::GetTeamName()
         static const auto REX = QRegularExpression("[\a\b\f\n\r\t\v]");
         namebuf = namebuf.replace(REX, "");
 
-        this->Name = namebuf;
+        QFontMetrics fm(QFont("Yu Gothic UI", 20));
+        QString clientName = "", lineText = "";
+        bool insertNewLineFlag = false;
+
+        for(int i = 0; i < namebuf.length(); i++){
+
+            //文字幅を計算して、ある程度以上の幅の文字列の表示をしない/改行して分割する
+            //(LIMIT_NAME_PIXEL_SIZE以上なら2行に分割)
+            if(fm.horizontalAdvance(lineText + namebuf[i]) < LIMIT_NAME_PIXEL_SIZE){
+                clientName += namebuf[i];
+                lineText += namebuf[i];
+            } else if (!insertNewLineFlag){
+                insertNewLineFlag = true;
+                clientName += "\n";
+                clientName += namebuf[i];
+                lineText = namebuf[i];
+            } else { //1回改行が入ったあとは、2行目まで表示する(3行目以降は無視)
+                break;
+            }
+
+        }
+
+        this->Name = clientName;
 
         disconnect(this->client, &QTcpSocket::readyRead, this, &TCPClient::GetTeamName);
 

--- a/src/TcpClient.h
+++ b/src/TcpClient.h
@@ -14,6 +14,7 @@ class TCPClient : public BaseClient
 private:
     int TIMEOUT = 5000;   //タイムアウト
     const static int IGNORE_INVALD = 10;   //無効ライン無視回数
+    const static int LIMIT_NAME_PIXEL_SIZE = 250;  //クライアント名1行分の最大ピクセルサイズ
 
     const QString NEWLINE_CODE = "";
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -239,6 +239,8 @@ void MainWindow::StepGame()
             }
             team_mehod[player].team = static_cast<GameSystem::TEAM>(player);
         }
+        //アイテムの回収
+        RefreshItem(team_mehod[player]);
         //End
         this->win = Judge();
 


### PR DESCRIPTION
* 長過ぎるクライアント名は受け付けないように変更
* サーバー再起動無しでサーバーの設定を変更できるように変更
* マニュアルクライアントのダイアログが邪魔にならない場所で開くように変更
* 特定の条件でアイテム数が正しく反映されないバグを修正