### PR TITLE
クライアント名、接続処理を改修

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Imageフォルダがない場合は新規作成してください。
 
 ## 開発環境(Qt6)
 - Windows 11 24H2
-- Qt Creator 16.0.1
-- Desktop Qt 6.8.3 MinGW 64-bit
+- Qt Creator 17.0.2
+- Desktop Qt 6.9.3 MinGW 64-bit
 
 ## 開発環境(Qt5)
 - MacOSX 10.11.3 ElCapitan

--- a/src/ClientSettingForm.cpp
+++ b/src/ClientSettingForm.cpp
@@ -27,7 +27,7 @@ ClientSettingForm::~ClientSettingForm()
 
 void ClientSettingForm::SetStandby()
 {
-    this->ui->NameLabel ->setText(this->client->Name == "" ? "Hot" : this->client->Name);
+    this->ui->NameLabel ->setText(this->client->Name == "" ? "未設定" : this->client->Name);
     this->ui->IPLabel   ->setText(this->client->IP);
     this->ui->StateLabel->setText("準備完了");
     //if(this->ui->ComboBox->currentText() != "TCPユーザー");

--- a/src/TcpClient.cpp
+++ b/src/TcpClient.cpp
@@ -149,6 +149,9 @@ void TCPClient::NewConnection()
     connect(this->client, &QTcpSocket::readyRead,    this, &TCPClient::GetTeamName);
 	connect(this->client, &QTcpSocket::disconnected, this, &TCPClient::DisConnected);
     is_disconnected = false;
+
+    //クライアントが1度接続された後は、接続を受け付けない
+    this->server->close();
     emit Connected();
 }
 


### PR DESCRIPTION
- Qtのバージョンを6.9.3に更新
- サーバーに同じポートで2つ以上のクライアントが接続しようとした際に、2つ目以降のクライアントからの接続を拒否するように改修
- クライアント名について、特殊な改行、ゼロ幅文字、サロゲート文字の場合でも正しく処理できるように改修
- クライアント名が空欄の場合は「未設定」と表示されるように変更